### PR TITLE
Fix a couple of bugs

### DIFF
--- a/scripts/build_dataset.py
+++ b/scripts/build_dataset.py
@@ -1,5 +1,5 @@
 import argparse
-import os
+import shutil
 from typing import Dict
 
 import yaml
@@ -191,7 +191,7 @@ def build_dataset(config_path: str, output_path: str, batch_size: int):
         num_proc=None,
     )
     dataset.save_to_disk(output_path)
-    os.remove("temp")
+    shutil.rmtree("temp")
 
 
 if __name__ == "__main__":

--- a/scripts/build_dataset.py
+++ b/scripts/build_dataset.py
@@ -180,7 +180,7 @@ def build_dataset(config_path: str, output_path: str, batch_size: int):
         lambda example: _get_example_safe(bmodel, example),
         desc="Building",
         writer_batch_size=batch_size,
-        num_proc=1,
+        num_proc=None,
         remove_columns=dataset.column_names,
         new_fingerprint=_fingerprint("map"),
     )
@@ -188,7 +188,7 @@ def build_dataset(config_path: str, output_path: str, batch_size: int):
         lambda x: x["input_ids"] is not None,
         desc="Filtering",
         writer_batch_size=batch_size,
-        num_proc=1,
+        num_proc=None,
     )
     dataset.save_to_disk(output_path)
     os.remove("temp")


### PR DESCRIPTION
So there were a couple of bugs I ran into while trying to run this on my machine:
1. There's no init file in ./llm_backdoor/models/ which makes it so that 'models' isn't installed as a module after running setup.py.
2. I couldn't get past the dataset building phase in build_dataset.py. By trial and error I found that datasets >= 4.1.0 changed something about how they handle num_proc. Instead of forcing a lower version in requirements.txt, I changed num_proc=1 to num_proc=None since it seems like this matches the behavior of versions < 4.1.0.
3. os.remove is being used for deleting the 'temp' folder after building the dataset. It will always fail since os.remove is for deleting files, not folders.

After these changes I finally got build_datasets.py to work correctly, but didn't have as much success with train_model.py:

```
Training model...
Epoch 1/1:   0%|                                                                                                                                  | 0/68 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/home/user/llm_backdoor/scripts/train_model.py", line 152, in <module>
    train_model(args.config, args.dataset, args.output_path)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/llm_backdoor/scripts/train_model.py", line 97, in train_model
    for batch_idx, batch in tqdm(
                            ~~~~^
        enumerate(dataloader),
        ^^^^^^^^^^^^^^^^^^^^^^
        total=len(dataloader),
        ^^^^^^^^^^^^^^^^^^^^^^
        desc=f"Epoch {epoch+1}/{num_epochs}",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ):
    ^
  File "/home/user/.venv/lib/python3.13/site-packages/tqdm/std.py", line 1181, in __iter__
    for obj in iterable:
               ^^^^^^^^
  File "/home/user/.venv/lib/python3.13/site-packages/torch/utils/data/dataloader.py", line 734, in __next__
    data = self._next_data()
  File "/home/user/.venv/lib/python3.13/site-packages/torch/utils/data/dataloader.py", line 790, in _next_data
    data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
  File "/home/user/.venv/lib/python3.13/site-packages/torch/utils/data/_utils/fetch.py", line 52, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
            ~~~~~~~~~~~~^^^^^
  File "/home/user/llm_backdoor/scripts/train_model.py", line 24, in __getitem__
    "input_embeds": torch.tensor(item["input_embeds"]),
                                 ~~~~^^^^^^^^^^^^^^^^
KeyError: 'input_embeds'
```

I figured that it could have something to do with some references to 'input_ids' being mistakenly called 'input_embeds'. Perhaps you forgot to replace all occurences in #2?

I would've tried fixing that as well but after getting it past that phase, my GPU seemingly ran out of VRAM and as such I wasn't able to test the correctness of the changes I made.